### PR TITLE
Não usamos mais o ajaxWrapper do Objeto Sieve.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Changelog
 
 * 0.3.0
-  > Passamos a depender do objeto Bridge (em vez do Sieve). Exige versçao da asgard UI 0.14.0+
+  > Passamos a depender do objeto Bridge (em vez do Sieve). Exige versão da asgard UI 0.14.0+
 
 
 ## Fazendo o build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Session checker plugin
 
+
+## Changelog
+
+* 0.3.0
+  > Passamos a depender do objeto Bridge (em vez do Sieve). Exige versçao da asgard UI 0.14.0+
+
+
 ## Fazendo o build
 
 Para gerar o main.js precisamos rodar:

--- a/src/js/actions/SessionCheckerAction.js
+++ b/src/js/actions/SessionCheckerAction.js
@@ -1,8 +1,8 @@
 const {
   PluginActions,
   PluginHelper,
-  config,
-  Sieve
+  Sieve,
+  MarathonService,
 } = window.marathonPluginInterface;
 
 var acceptDialog = function (dialog) {
@@ -25,9 +25,12 @@ function checkStatusCode(statusCode) {
 Sieve.DialogStore.on("DIALOG_EVENTS_ACCEPT_DIALOG", acceptDialog);
 
 function checkSession() {
-  Sieve.ajaxWrapper({
-    url: `${config.apiURL}v2/deployments`,
+  MarathonService.request({
+    resource: "v2/deployments",
     concurrent: true
+  })
+  .success(response => {
+
   })
   .error(function (error) {
     checkStatusCode(error.status);

--- a/src/js/components/ChangeAccountComponent.jsx
+++ b/src/js/components/ChangeAccountComponent.jsx
@@ -7,7 +7,7 @@ const {
   PluginActions,
   PluginHelper,
   Sieve,
-  config,
+  MarathonService,
 } = window.marathonPluginInterface;
 
 function showErrorDialog(title, message) {
@@ -41,8 +41,8 @@ var ChangeAccountComponent = React.createClass({
 
   acceptChangeAccountDialog: function (dialog) {
     if (dialog.myid === "session-account-change") {
-      Sieve.ajaxWrapper({
-        url: `${config.apiURL}hollow/account/next`,
+      MarathonService.request({
+        resource: "hollow/account/next",
         method: "POST"
       })
       .error(error => {
@@ -65,7 +65,7 @@ var ChangeAccountComponent = React.createClass({
 
   whoAmI: function () {
     /* eslint-disable no-unused-vars */
-    Sieve.ajaxWrapper({url: `${config.apiURL}hollow/account/me`, method: "GET"})
+    MarathonService.request({resource: "hollow/account/me", method: "GET"})
       .error(error => {
         /* Não temos muito o que fazer aqui. Se retornar erro,
          * já estamos deslogados e isso já é tratado por outra

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,7 +5,7 @@ const {
   PipelineStore,
 } = window.marathonPluginInterface;
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 
 import SessionCheckerAction from "./actions/SessionCheckerAction";
 import ChangeAccountComponent from "./components/ChangeAccountComponent";


### PR DESCRIPTION
Agora que foi criado o MarathonService, essa é a forma correta de fazer
requests AJAX. Essa forma encapsula até mesmo a BASE_URL da API com a
qual a UI está conversando.